### PR TITLE
Make output directory empty by default

### DIFF
--- a/microshift-okd-multi-build.Containerfile
+++ b/microshift-okd-multi-build.Containerfile
@@ -9,7 +9,7 @@ ENV USER=microshift
 ENV HOME=/microshift
 #ENV MICROSHIFT_SRC=
 ENV GOPATH=/microshift
-ENV OUTPUT_DIR=/output
+ENV OUTPUT_DIR=
 ENV GOMODCACHE=/microshift/.cache
 
 RUN dnf install -y git && git clone ${USHIFT_GIT_URL} /microshift


### PR DESCRIPTION
This will prevent following error
```
[1/2] STEP 20/20: RUN if [ -n "$OUTPUT_DIR" ] ; then       cp -rf /microshift/_output/* ${OUTPUT_DIR}/;     fi
cp: target '/output/' is not a directory
Error: building at STEP "RUN if [ -n "$OUTPUT_DIR" ] ; then       cp -rf /microshift/_output/* ${OUTPUT_DIR}/;     fi": while running runtime: exit status 1
```