### PR TITLE
USHIFT-6151: Refactor MicroShift build and run procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 #
 USHIFT_BRANCH ?= main
 OKD_VERSION_TAG ?=
+RPM_OUTDIR ?=
 WITH_KINDNET ?= 1
 WITH_TOPOLVM ?= 1
 WITH_OLM ?= 0
@@ -36,7 +37,7 @@ endif
     	--env WITH_TOPOLVM="${WITH_TOPOLVM}" \
     	--env WITH_OLM="${WITH_OLM}" \
     	-t microshift-okd -f packaging/microshift-cos9.Containerfile . && \
-	outdir="$$(mktemp -d /tmp/microshift-rpms-XXXXXX)" && \
+	outdir="$${RPM_OUTDIR:-$$(mktemp -d /tmp/microshift-rpms-XXXXXX)}" && \
 	mntdir="$$(sudo podman image mount microshift-okd)" && \
 	sudo cp -r "$${mntdir}/microshift/_output/rpmbuild/RPMS/." "$${outdir}" && \
 	sudo podman image umount microshift-okd && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+#
+# The following variables can be overriden from the command line
+# using NAME=value make arguments
+#
+USHIFT_BRANCH ?= main
+OKD_VERSION_TAG ?=
+WITH_KINDNET ?= 1
+WITH_TOPOLVM ?= 1
+WITH_OLM ?= 0
+EMBED_CONTAINER_IMAGES ?= 0
+
+#
+# Define the main targets
+#
+.PHONY: all
+all:
+	@echo "make <rpm | image | run | login | stop | clean>"
+	@echo "   rpm:      build the MicroShift RPMs"
+	@echo "   image:    build the MicroShift bootc container image"
+	@echo "   run:      run the MicroShift bootc container"
+	@echo "   login:    login to the MicroShift bootc container"
+	@echo "   stop:     stop the MicroShift bootc container"
+	@echo "   clean:    clean up the MicroShift container"
+	@echo ""
+
+.PHONY: rpm
+rpm:
+ifndef OKD_VERSION_TAG
+	$(error Run 'make rpm USHIFT_BRANCH=value OKD_VERSION_TAG=value')
+endif
+	@echo "Building the MicroShift RPMs"
+	sudo podman build --target builder \
+    	--build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
+    	--build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
+    	--env WITH_KINDNET="${WITH_KINDNET}" \
+    	--env WITH_TOPOLVM="${WITH_TOPOLVM}" \
+    	--env WITH_OLM="${WITH_OLM}" \
+    	-t microshift-okd -f packaging/microshift-cos9.Containerfile . && \
+	outdir="$$(mktemp -d /tmp/microshift-rpms-XXXXXX)" && \
+	mntdir="$$(sudo podman image mount microshift-okd)" && \
+	sudo cp -r "$${mntdir}/microshift/_output/rpmbuild/RPMS/." "$${outdir}" && \
+	sudo podman image umount microshift-okd && \
+	echo "" && \
+	echo "Build completed successfully" && \
+	echo "RPMs are available in '$${outdir}'"
+
+.PHONY: image
+image:
+ifndef OKD_VERSION_TAG
+	$(error Run 'make image USHIFT_BRANCH=value OKD_VERSION_TAG=value')
+endif
+	@echo "Building the MicroShift bootc container image"
+	sudo podman build \
+    	--build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
+    	--build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
+    	--env WITH_KINDNET="${WITH_KINDNET}" \
+    	--env WITH_TOPOLVM="${WITH_TOPOLVM}" \
+    	--env WITH_OLM="${WITH_OLM}" \
+    	--env EMBED_CONTAINER_IMAGES="${EMBED_CONTAINER_IMAGES}" \
+    	-t microshift-okd -f packaging/microshift-cos9.Containerfile .
+
+# Prerequisites for running the MicroShift container:
+# - If the OVN-K CNI driver is used (`WITH_KINDNET=0` non-default build option),
+#   the `openvswitch` module must be loaded on the host.
+# - If the TopoLVM CSI driver is used (`WITH_TOPOLVM=1` default build option),
+#   the /dev/dm-* device must be shared with the container.
+.PHONY: run
+run:
+	@echo "Running the MicroShift container"
+	sudo modprobe openvswitch
+	sudo podman run --privileged --rm -d \
+		--name microshift-okd \
+		--volume /dev:/dev:rslave \
+		microshift-okd
+
+.PHONY: login
+login:
+	@echo "Logging into the MicroShift container"
+	sudo podman exec -it microshift-okd bash
+
+.PHONY: stop
+stop:
+	@echo "Stopping the MicroShift container"
+	sudo podman stop --time 0 microshift-okd || true
+
+.PHONY: clean
+clean:
+	@echo "Cleaning up the MicroShift container"
+	sudo podman rmi -f microshift-okd || true
+	sudo rmmod openvswitch || true

--- a/README.md
+++ b/README.md
@@ -1,125 +1,21 @@
-# MicroShift upstream Build and Run Scripts
-This repository provides scripts to build and run [MicroShift](https://github.com/openshift/microshift/) upstream.
+# MicroShift Upstream
+
+This repository provides scripts to build and run [MicroShift](https://github.com/openshift/microshift/)
+upstream (i.e. without Red Hat subscriptions or a pull secrets).
 
 ## Overview
 
-MicroShift is a project that optimizes OpenShift Kubernetes for small form factor and edge computing.
- It is intended for upstream development and testing by building MicroShift directly from the original OpenShift MicroShift sources, while replacing the default payload images with OKD (the community distribution of Kubernetes that powers OpenShift).
+MicroShift is a project that optimizes OpenShift Kubernetes for small form factor
+and edge computing. MicroShift Upstream is intended for upstream development and
+testing by allowing to build MicroShift directly from the original OpenShift MicroShift
+sources, while replacing the default payload images with OKD (the community distribution
+of Kubernetes that powers OpenShift).
 
-The goal is to enable contributors and testers to work with a fully open-source MicroShift setup using OKD components, making it easier to develop, verify, and iterate on features outside the downstream Red Hat payloads.
+The goal is to enable contributors and testers to work with an upstream build of MicroShift
+set up using OKD components, making it easier to develop, verify, and iterate on features
+outside the downstream Red Hat payloads.
 
-## MicroShift Upstream Build Process
+## Build and Run
 
-The RPM/container build process includes the following steps:
-
-1. Replace the MicroShift payload/images with the OKD [released images](https://github.com/okd-project/okd-scos/releases).
-2. Build the MicroShift RPMs and repository from the MicroShift source.
-3. Build the `microshift-okd` Bootc container based on `centos-bootc:stream9`.
-4. Apply upstream customizations (see below).
-
-## Build and Run Microshift upstream without subscription/pull-secret
-- Use a specific microshift branch (default main)
-  ```
-  sudo podman build --build-arg USHIFT_BRANCH=release-4.19 -f microshift-okd-multi-build.Containerfile . -t microshift-okd 
-  ```
-- Only build the RPMs 
-  ```bash
-  sudo podman build --target builder --env WITH_KINDNET=1 --env WITH_TOPOLVM=1 -f microshift-okd-multi-build.Containerfile . -t microshift-okd
-  ```
-- Build the RPMs & container locally using podman
-
-  - use `ovn-kubernetes` as CNI (default)
-    ```bash
-        sudo podman build -f microshift-okd-multi-build.Containerfile . -t microshift-okd
-    ```
-  - To use kindnet as CNI
-    ```bash
-        sudo podman build --env WITH_KINDNET=1 -f microshift-upstream/microshift-okd-multi-build.Containerfile . -t microshift-okd-4.19
-    ```
-  - To install OLM as part of image
-    ```bash
-       sudo podman build --env WITH_OLM=1 -f microshift-upstream/microshift-okd-multi-build.Containerfile . -t microshift-okd-4.19
-    ```
-  - To embed all component images
-    ```bash
-        sudo podman build --env EMBED_CONTAINER_IMAGES=1 -f microshift-upstream/microshift-okd-multi-build.Containerfile . -t microshift-okd
-    ```
-  - To use kindnet CNI with [TopoLVM](https://github.com/topolvm/topolvm) upstream as CSI 
-    ```bash
-        sudo podman build --env WITH_KINDNET=1 --env WITH_TOPOLVM=1 -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
-    ```
-
-- running the container with ovn-kubernetes 
-  - make sure to load the openvswitch kernel module  :
-    > `sudo modprobe openvswitch`
-
-  - run the container :
-    > `sudo podman run --privileged --rm --name microshift-okd -d microshift-okd`
-
-- running the container with TopoLVM upstream
-
-    1. Prepare the LVM backend on the host (example only)
-        ```bash
-            sudo truncate --size=20G /tmp/lvmdisk
-            sudo losetup -f /tmp/lvmdisk
-            device_name=$(losetup -j /tmp/lvmdisk | cut -d: -f1)
-            sudo vgcreate -f -y myvg1 ${device_name}
-            sudo lvcreate -T myvg1/thinpool -L 6G
-        ```
-
-    1. Run microshift in container and wait for it to be ready
-        ```bash
-            sudo podman run --privileged --rm --name microshift-okd \
-            --volume /dev:/dev:rslave \
-            -d localhost/microshift-okd
-        ```
-        Note:  We need to mount the entire /dev directory here, as LVM management requires full visibility of new volumes under /dev/dm-*.
-    1. Wait for all the components to come up 
-        ```bash
-        > sudo podman exec  microshift-okd bash -c "microshift healthcheck --namespace topolvm-system --deployments topolvm-controller "
-        ??? I0331 14:38:46.838208    5894 service.go:29] microshift.service is enabled 
-        ??? I0331 14:38:46.838235    5894 service.go:31] Waiting 5m0s for microshift.service to be ready
-        ??? I0331 14:38:46.839291    5894 service.go:38] microshift.service is ready
-        ??? I0331 14:38:46.840014    5894 workloads.go:94] Waiting 5m0s for deployment/topolvm-controller in topolvm-system
-        ??? I0331 14:38:46.844984    5894 workloads.go:132] Deployment/topolvm-controller in topolvm-system is ready
-        ??? I0331 14:38:46.845003    5894 healthcheck.go:75] Workloads are ready
-
-        > oc get pods -A
-        NAMESPACE              NAME                                       READY   STATUS    RESTARTS        AGE
-        cert-manager           cert-manager-5f864bbfd-bpd6h               1/1     Running   0               4m49s
-        cert-manager           cert-manager-cainjector-589dc747b5-cfwjf   1/1     Running   0               4m49s
-        cert-manager           cert-manager-webhook-5987c7ff58-mzq6l      1/1     Running   0               4m49s
-        kube-kindnet           kube-kindnet-ds-6nvq6                      1/1     Running   0               4m12s
-        kube-proxy             kube-proxy-zlvb2                           1/1     Running   0               4m12s
-        kube-system            csi-snapshot-controller-75d84cb97c-nkfsz   1/1     Running   0               4m50s
-        openshift-dns          dns-default-dbjh4                          2/2     Running   0               4m1s
-        openshift-dns          node-resolver-mt8m7                        1/1     Running   0               4m12s
-        openshift-ingress      router-default-59cbb858cc-6mzbx            1/1     Running   0               4m49s
-        openshift-service-ca   service-ca-df6759f9d-24d2n                 1/1     Running   0               4m49s
-        topolvm-system         topolvm-controller-9cd8649c9-5tcln         5/5     Running   0               4m49s
-        topolvm-system         topolvm-lvmd-0-2bmjq                       1/1     Running   0               4m1s
-        topolvm-system         topolvm-node-lwxz5                         3/3     Running   1 (3m36s ago)   4m1s
-        ```
-- connect to the container
-   > `sudo podman exec -ti microshift-okd /bin/bash`
-
-- verify everything is working:
-  ```bash
-    export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
-    > oc get nodes  
-    NAME           STATUS   ROLES                         AGE     VERSION
-    d2877aa41787   Ready    control-plane,master,worker   7m39s   v1.30.3
-    
-    > oc get pods
-    NAMESPACE                  NAME                                       READY   STATUS    RESTARTS        AGE
-    kube-system                csi-snapshot-controller-7d6c78bc58-5p7tb   1/1     Running   0               8m52s
-    openshift-dns              dns-default-2q89q                          2/2     Running   0               7m34s
-    openshift-dns              node-resolver-k2c5h                        1/1     Running   0               8m54s
-    openshift-ingress          router-default-db4b598b9-x8lvb             1/1     Running   0               8m52s
-    openshift-ovn-kubernetes   ovnkube-master-c75c7                       4/4     Running   1 (7m36s ago)   8m54s
-    openshift-ovn-kubernetes   ovnkube-node-jfx86                         1/1     Running   0               8m54s
-    openshift-service-ca       service-ca-68d58669f8-rns2p                1/1     Running   0               8m51s
-
-
-  ```
-  
+* [Build MicroShift Upstream](./docs/build.md)
+* [Run MicroShift Upstream](./docs/run.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -15,14 +15,15 @@ commands.
 The following options can be specified in the make command line using the
 `NAME=VAL` format.
 
-|Name                  |Required|Default|Comments
-|----------------------|--------|-------|--------
-|USHIFT_BRANCH         |no      |main   |[List of branches](https://github.com/openshift/microshift/branches)
-|OKD_VERSION_TAG       |yes     |       |[List of tags](https://quay.io/repository/okd/scos-release?tab=tags)
-|WITH_KINDNET          |no      |1      |OVK-K CNI is used when Kindnet is disabled
-|WITH_TOPOLVM          |no      |1      |Enable [TopoLVM](https://github.com/topolvm/topolvm) CSI
-|WITH_OLM              |no      |0      |Enable OLM support
-|EMBED_CONTAINER_IMAGES|no      |0      |Embed all component container dependencies in Bootc images
+|Name                  |Required|Default |Comments
+|----------------------|--------|--------|--------
+|USHIFT_BRANCH         |no      |main    |[List of branches](https://github.com/openshift/microshift/branches)
+|OKD_VERSION_TAG       |yes     |        |[List of tags](https://quay.io/repository/okd/scos-release?tab=tags)
+|RPM_OUTDIR            |no      |/tmp/...|RPM repository output directory for `make rpm`
+|WITH_KINDNET          |no      |1       |OVK-K CNI is used when Kindnet is disabled
+|WITH_TOPOLVM          |no      |1       |Enable [TopoLVM](https://github.com/topolvm/topolvm) CSI
+|WITH_OLM              |no      |0       |Enable OLM support
+|EMBED_CONTAINER_IMAGES|no      |0       |Embed all component container dependencies in Bootc images
 
 ### Build MicroShift RPMs
 
@@ -39,10 +40,18 @@ make rpm \
 ```
 
 If the build completes successfully, the MicroShift RPM repository is copied to
-a temporary directory on the host. The packages from this repository can be used
-to install MicroShift on the supported operating systems.
+the `RPM_OUTDIR` directory on the host. The packages from this repository can be
+used to install MicroShift on the supported operating systems.
 
-Note: The path to the temporary directory is displayed in the end of the build procedure.
+Note: The path to the `RPM_OUTDIR` directory (either temporary or specified in
+the `make rpm` command line) is displayed in the end of the build procedure.
+
+```
+...
+...
+Build completed successfully
+RPMs are available in '/tmp/microshift-rpms-EI3IXg'
+```
 
 ### Build MicroShift Bootc Image
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -7,21 +7,18 @@ The build process is containerized and it includes the following steps:
 1. Build the MicroShift RPMs and repository from the MicroShift sources.
 1. Build the `microshift-okd` Bootc container based on CentOS Stream.
 
-### Build Arguments and Options
+### Build Options
 
-The following arguments can be specified in the build command using the
-`--build-arg NAME=VAL` format.
+Building MicroShift artifacts is performed by running `make rpm` or `make image`
+commands.
 
-|Name           |Required|Default|Comments
-|---------------|--------|-------|--------
-|USHIFT_BRANCH  |no      |main   |[List of branches](https://github.com/openshift/microshift/branches)
-|OKD_VERSION_TAG|yes     |none   |[List of tags](https://quay.io/repository/okd/scos-release?tab=tags)
-
-The following options can be specified in the build command using
-the `--build-env NAME=VAL` format.
+The following options can be specified in the make command line using the
+`NAME=VAL` format.
 
 |Name                  |Required|Default|Comments
 |----------------------|--------|-------|--------
+|USHIFT_BRANCH         |no      |main   |[List of branches](https://github.com/openshift/microshift/branches)
+|OKD_VERSION_TAG       |yes     |       |[List of tags](https://quay.io/repository/okd/scos-release?tab=tags)
 |WITH_KINDNET          |no      |1      |OVK-K CNI is used when Kindnet is disabled
 |WITH_TOPOLVM          |no      |1      |Enable [TopoLVM](https://github.com/topolvm/topolvm) CSI
 |WITH_OLM              |no      |0      |Enable OLM support
@@ -29,63 +26,36 @@ the `--build-env NAME=VAL` format.
 
 ### Build MicroShift RPMs
 
-Run the following command to build MicroShift RPMs based on CentOS Stream 9
+Run the `make rpm` command to build MicroShift RPMs based on CentOS Stream 9
 operating system.
 
-Note that the `--target builder` option only enabled the necessary RPM build steps
-without proceeding with the Bootc image creation.
-
-```bash
+```
 USHIFT_BRANCH=release-4.19
 OKD_VERSION_TAG=4.19.0-okd-scos.19
 
-sudo podman build --target builder \
-    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
-    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
-    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
+make rpm \
+  USHIFT_BRANCH="${USHIFT_BRANCH}" \
+  OKD_VERSION_TAG="${OKD_VERSION_TAG}"
 ```
 
-If the build completes successfully, run the following commands to copy the RPM
-packages from the container image to the host file system. The MicroShift RPM
-repository is copied to the `OUTPUT_DIR` directory on the host.
+If the build completes successfully, the MicroShift RPM repository is copied to
+a temporary directory on the host. The packages from this repository can be used
+to install MicroShift on the supported operating systems.
 
-```bash
-OUTPUT_DIR=/tmp/microshift-rpms
-mkdir -p "${OUTPUT_DIR}"
-
-mdir=$(sudo podman image mount microshift-okd)
-sudo cp -r "${mdir}/microshift/_output/rpmbuild/RPMS/." "${OUTPUT_DIR}"
-sudo podman image umount microshift-okd
-```
-
-The packages from this repository can be used to install MicroShift on the
-supported operating systems.
+Note: The path to the temporary directory is displayed in the end of the build procedure.
 
 ### Build MicroShift Bootc Image
 
-Run the following command to build a MicroShift Bootc image based on CentOS
+Run the `make image` command to build a MicroShift Bootc image based on CentOS
 Stream 9 operating system with the default options.
 
 ```bash
 USHIFT_BRANCH=release-4.19
 OKD_VERSION_TAG=4.19.0-okd-scos.19
 
-sudo podman build \
-    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
-    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
-    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
+make image \
+  USHIFT_BRANCH="${USHIFT_BRANCH}" \
+  OKD_VERSION_TAG="${OKD_VERSION_TAG}"
 ```
 
-As an example of non-default options, run the following command to embed all
-component container image dependencies during the build.
-
-```bash
-USHIFT_BRANCH=release-4.19
-OKD_VERSION_TAG=4.19.0-okd-scos.19
-
-sudo podman build \
-    --build-env EMBED_CONTAINER_IMAGES=1 \
-    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
-    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
-    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
-```
+If the build completes successfully, the `microshift-okd` image is created.

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,91 @@
+## Build MicroShift Upstream
+
+### Overview
+The build process is containerized and it includes the following steps:
+
+1. Replace the MicroShift payload/images with the OKD [released images](https://github.com/okd-project/okd-scos/releases).
+1. Build the MicroShift RPMs and repository from the MicroShift sources.
+1. Build the `microshift-okd` Bootc container based on CentOS Stream.
+
+### Build Arguments and Options
+
+The following arguments can be specified in the build command using the
+`--build-arg NAME=VAL` format.
+
+|Name           |Required|Default|Comments
+|---------------|--------|-------|--------
+|USHIFT_BRANCH  |no      |main   |[List of branches](https://github.com/openshift/microshift/branches)
+|OKD_VERSION_TAG|yes     |none   |[List of tags](https://quay.io/repository/okd/scos-release?tab=tags)
+
+The following options can be specified in the build command using
+the `--build-env NAME=VAL` format.
+
+|Name                  |Required|Default|Comments
+|----------------------|--------|-------|--------
+|WITH_KINDNET          |no      |1      |OVK-K CNI is used when Kindnet is disabled
+|WITH_TOPOLVM          |no      |1      |Enable [TopoLVM](https://github.com/topolvm/topolvm) CSI
+|WITH_OLM              |no      |0      |Enable OLM support
+|EMBED_CONTAINER_IMAGES|no      |0      |Embed all component container dependencies in Bootc images
+
+### Build MicroShift RPMs
+
+Run the following command to build MicroShift RPMs based on CentOS Stream 9
+operating system.
+
+Note that the `--target builder` option only enabled the necessary RPM build steps
+without proceeding with the Bootc image creation.
+
+```bash
+USHIFT_BRANCH=release-4.19
+OKD_VERSION_TAG=4.19.0-okd-scos.19
+
+sudo podman build --target builder \
+    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
+    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
+    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
+```
+
+If the build completes successfully, run the following commands to copy the RPM
+packages from the container image to the host file system. The MicroShift RPM
+repository is copied to the `OUTPUT_DIR` directory on the host.
+
+```bash
+OUTPUT_DIR=/tmp/microshift-rpms
+mkdir -p "${OUTPUT_DIR}"
+
+mdir=$(sudo podman image mount microshift-okd)
+sudo cp -r "${mdir}/microshift/_output/rpmbuild/RPMS/." "${OUTPUT_DIR}"
+sudo podman image umount microshift-okd
+```
+
+The packages from this repository can be used to install MicroShift on the
+supported operating systems.
+
+### Build MicroShift Bootc Image
+
+Run the following command to build a MicroShift Bootc image based on CentOS
+Stream 9 operating system with the default options.
+
+```bash
+USHIFT_BRANCH=release-4.19
+OKD_VERSION_TAG=4.19.0-okd-scos.19
+
+sudo podman build \
+    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
+    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
+    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
+```
+
+As an example of non-default options, run the following command to embed all
+component container image dependencies during the build.
+
+```bash
+USHIFT_BRANCH=release-4.19
+OKD_VERSION_TAG=4.19.0-okd-scos.19
+
+sudo podman build \
+    --build-env EMBED_CONTAINER_IMAGES=1 \
+    --build-arg USHIFT_BRANCH="${USHIFT_BRANCH}" \
+    --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
+    -t microshift-okd -f packaging/microshift-cos9.Containerfile .
+```

--- a/docs/run.md
+++ b/docs/run.md
@@ -66,21 +66,15 @@ sudo modprobe openvswitch
 Run the following command to start MicroShift inside a Bootc container.
 
 ```bash
-sudo podman run --privileged --rm -d \
-  --name microshift-okd \
-  --volume /dev:/dev:rslave \
-  microshift-okd
+make run
 ```
-
-Note: It is necessary to mount the entire `/dev` directory tree inside the constainer,
-as LVM management requires full visibility of the new volumes under `/dev/dm-*`.
 
 ### Container Login
 
 Log into the container by running the following command.
 
 ```bash
-sudo podman exec -it microshift-okd bash
+make login
 ```
 
 Verify that all the MicroShift services are up and running successfully.
@@ -96,7 +90,7 @@ oc get pods -A
 Run the following command to stop the MicroShift Bootc container.
 
 ```bash
-sudo podman stop --time 0 microshift-okd
+make stop
 ```
 
 ## Cleanup
@@ -113,17 +107,19 @@ sudo dnf remove -y microshift*
 
 ### Bootc Containers
 
-Run the following commands to stop MicroShift Bootc containers and clean up any
-LVM volumes or kernel modules.
+Run the following commands to delete MicroShift Bootc container images.
+
+```bash
+make clean
+```
+
+Finally, clean up any LVM volumes.
 
 ```bash
 LVM_DISK=/var/db/lvmdisk.image
 VG_NAME=myvg1
 
-sudo podman stop --time 0 microshift-okd
-sudo rmmod openvswitch
 sudo vgremove -y "${VG_NAME}"
-
 DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
 [ -n "${DEVICE_NAME}" ] && sudo losetup -d "${DEVICE_NAME}"
 sudo rm -f "${LVM_DISK}"

--- a/docs/run.md
+++ b/docs/run.md
@@ -1,0 +1,130 @@
+# Run MicroShift Upstream
+
+MicroShift can be run on the host or inside a Bootc container.
+
+## MicroShift RPMs
+
+### Prerequisites
+
+MicroShift requires the `openvswitch` package. The installation instructions may
+vary depending on the current operating system.
+
+For example, on CentOS Stream, the following command should be run to enable the
+appropriate repository.
+
+```bash
+sudo dnf install -y centos-release-nfv-openvswitch
+```
+
+### Install RPM Packages
+
+Run the following command to install MicroShift RPM package from the local
+repository copied from the build container image.
+See [Build MicroShift RPMs](../docs/build.md#build-microshift-rpms) for more information.
+
+```bash
+RPM_REPO_DIR=/tmp/microshift-rpms
+
+sudo dnf install microshift \
+  --repofrompath=microshift-local,"${RPM_REPO_DIR}" \
+  --setopt=microshift-local.gpgcheck=0
+```
+
+## MicroShift Bootc Image
+
+### Prerequisites
+
+#### TopoLVM Backend
+
+Prepare the TopoLVM CSI backend on the host to be used by MicroShift when compiled
+with the default `WITH_TOPOLVM=1` built option.
+
+```bash
+LVM_DISK=/var/db/lvmdisk.image
+VG_NAME=myvg1
+
+sudo truncate --size=20G "${LVM_DISK}"
+sudo losetup -f "${LVM_DISK}"
+
+DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
+sudo vgcreate -f -y "${VG_NAME}" "${DEVICE_NAME}"
+```
+
+#### OVN-K Configuration
+
+If OVN-K CNI driver is used (`WITH_KINDNET=0` non-default build option), the
+`openvswitch` module must be loaded on the host by running the following command.
+
+```bash
+sudo modprobe openvswitch
+```
+
+## MicroShift In a Bootc Container
+
+### Start the Container
+
+Run the following command to start MicroShift inside a Bootc container.
+
+```bash
+sudo podman run --privileged --rm -d \
+  --name microshift-okd \
+  --volume /dev:/dev:rslave \
+  microshift-okd
+```
+
+Note: It is necessary to mount the entire `/dev` directory tree inside the constainer,
+as LVM management requires full visibility of the new volumes under `/dev/dm-*`.
+
+### Container Login
+
+Log into the container by running the following command.
+
+```bash
+sudo podman exec -it microshift-okd bash
+```
+
+Verify that all the MicroShift services are up and running successfully.
+
+```bash
+export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
+oc get nodes
+oc get pods -A
+```
+
+### Stop the Container
+
+Run the following command to stop the MicroShift Bootc container.
+
+```bash
+sudo podman stop --time 0 microshift-okd
+```
+
+## Cleanup
+
+### RPM
+
+Run the following command to delete all the MicroShift data and uninstall the
+MicroShift RPM packages.
+
+```bash
+echo y | sudo microshift-cleanup-data --all
+sudo dnf remove -y microshift*
+```
+
+### Bootc Containers
+
+Run the following commands to stop MicroShift Bootc containers and clean up any
+LVM volumes or kernel modules.
+
+```bash
+LVM_DISK=/var/db/lvmdisk.image
+VG_NAME=myvg1
+
+sudo podman stop --time 0 microshift-okd
+sudo rmmod openvswitch
+sudo vgremove -y "${VG_NAME}"
+
+DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
+[ -n "${DEVICE_NAME}" ] && sudo losetup -d "${DEVICE_NAME}"
+sudo rm -f "${LVM_DISK}"
+```

--- a/packaging/microshift-cos9.Containerfile
+++ b/packaging/microshift-cos9.Containerfile
@@ -1,18 +1,29 @@
 FROM quay.io/centos-bootc/centos-bootc:stream9 as builder
 
-	
 ARG OKD_REPO=quay.io/okd/scos-release
-ARG OKD_VERSION_TAG=4.18.0-okd-scos.4
-ARG REPO_DIR=/microshift/_output/rpmbuild/RPMS/
+ARG OKD_VERSION_TAG=""
 ARG USHIFT_GIT_URL=https://github.com/openshift/microshift.git
 ARG USHIFT_BRANCH=main
 ENV USER=microshift
 ENV HOME=/microshift
-#ENV MICROSHIFT_SRC=
+ARG REPO_DIR=/microshift/_output/rpmbuild/RPMS/
 ENV GOPATH=/microshift
 ENV GOMODCACHE=/microshift/.cache
 
-RUN dnf install -y git && git clone --branch ${USHIFT_BRANCH} --single-branch ${USHIFT_GIT_URL} /microshift
+# Environment variables controlling the list of MicroShift components to build
+ENV WITH_KINDNET=${WITH_KINDNET:-1}
+ENV WITH_TOPOLVM=${WITH_TOPOLVM:-1}
+ENV WITH_OLM=${WITH_OLM:-0}
+
+# Verify mandatory build arguments
+RUN if [ -z "${OKD_VERSION_TAG}" ]; then \
+        echo "Error: OKD_VERSION_TAG is not set"; \
+        echo "See quay.io/okd/scos-release for a list of tags"; \
+        exit 1; \
+    fi
+
+# Install git and clone the MicroShift repository
+RUN dnf install -y git && git clone --branch "${USHIFT_BRANCH}" --single-branch "${USHIFT_GIT_URL}" /microshift
 
 # Adding non-root user for building microshift
 RUN useradd -m -s /bin/bash microshift -d /microshift && \
@@ -20,7 +31,7 @@ RUN useradd -m -s /bin/bash microshift -d /microshift && \
     chmod 0640 /etc/shadow
 COPY ./src /src
 
-
+# Set the user and group for the microshift user
 RUN chown -R microshift:microshift /microshift /src
 USER microshift:microshift
 WORKDIR /microshift
@@ -28,24 +39,26 @@ WORKDIR /microshift
 # Preparing for the build
 RUN echo '{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}' > /tmp/.pull-secret && \
    /microshift/scripts/devenv-builder/configure-vm.sh --no-build --no-set-release-version --skip-dnf-update /tmp/.pull-secret && \
-   /src/use_okd_assets.sh --replace ${OKD_REPO} ${OKD_VERSION_TAG}
+   /src/use_okd_assets.sh --replace "${OKD_REPO}" "${OKD_VERSION_TAG}"
 
-#WORKDIR /microshift
 # Building Microshift RPMs and local repo
-RUN make build && \
-    make rpm && \
-    createrepo ${REPO_DIR}
+RUN WITH_KINDNET="${WITH_KINDNET}" WITH_TOPOLVM="${WITH_TOPOLVM}" WITH_OLM="${WITH_OLM}" \
+        make rpm srpm && \
+    createrepo -v "${REPO_DIR}"
 
-USER root:root
-RUN if [ -n "$OUTPUT_DIR" ] ; then \
-      cp -rf /microshift/_output/* ${OUTPUT_DIR}/; \
-    fi
-# Building microshift container from local rpms
-FROM quay.io/centos-bootc/centos-bootc:stream9 
+# Building microshift container from local RPMs
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
 ARG REPO_CONFIG_SCRIPT=/tmp/create_repos.sh
 ARG OKD_CONFIG_SCRIPT=/tmp/configure.sh
 ARG USHIFT_RPM_REPO_NAME=microshift-local
 ARG USHIFT_RPM_REPO_PATH=/tmp/rpm-repo
+
+# Environment variables controlling the list of MicroShift components to build
+ENV WITH_KINDNET=${WITH_KINDNET:-1}
+ENV WITH_TOPOLVM=${WITH_TOPOLVM:-1}
+ENV WITH_OLM=${WITH_OLM:-0}
+ENV EMBED_CONTAINER_IMAGES=${EMBED_CONTAINER_IMAGES:-0}
 
 ENV KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
 COPY --chmod=755 ./src/create_repos.sh ${REPO_CONFIG_SCRIPT}
@@ -57,27 +70,26 @@ RUN dnf install -y centos-release-nfv-openvswitch && \
     dnf clean all
 
 # Installing MicroShift and cleanup
-# In case of kindnet we don't need openvswitch service which is by default enabled as part
-# once microshift is installed so better to disable it because it cause issue when required
-# module is not enabled.
+# With kindnet enabled, we do not need openvswitch service which is enabled by default
+# once MicroShift is installed. Disable the service to avoid the need to configure it.
 RUN ${REPO_CONFIG_SCRIPT} ${USHIFT_RPM_REPO_PATH} && \
     dnf install -y microshift microshift-release-info && \
-    if [ -n "$WITH_KINDNET" ] ; then \
+    if [ -n "${WITH_KINDNET}" ] ; then \
         dnf install -y microshift-kindnet microshift-kindnet-release-info; \
         systemctl disable openvswitch ; \
     fi && \
-    if [ -n "$WITH_TOPOLVM" ] ; then \
+    if [ -n "${WITH_TOPOLVM}" ] ; then \
         dnf install -y microshift-topolvm ; \
     fi && \
-    if [ -n "$WITH_OLM" ] ; then \
+    if [ -n "${WITH_OLM}" ] ; then \
         dnf install -y microshift-olm microshift-olm-release-info ; \
     fi && \
     ${REPO_CONFIG_SCRIPT} -delete && \
     rm -f ${REPO_CONFIG_SCRIPT} && \
     rm -rf $USHIFT_RPM_REPO_PATH && \
     dnf clean all
-    
-RUN ${OKD_CONFIG_SCRIPT} && rm -rf ${OKD_CONFIG_SCRIPT}
+
+RUN ${OKD_CONFIG_SCRIPT} && rm -vf ${OKD_CONFIG_SCRIPT}
 
 # If the EMBED_CONTAINER_IMAGES environment variable is set to 1:
 # 1. Temporarily configure user namespace UID and GID mappings by writing to /etc/subuid and  /etc/subgid and clean it later
@@ -86,16 +98,16 @@ RUN ${OKD_CONFIG_SCRIPT} && rm -rf ${OKD_CONFIG_SCRIPT}
 #       - FATA[0129] copying system image from manifest list:[...]unpacking failed (error: exit status 1; output: potentially insufficient UIDs or GIDs available[...]
 # 2. Extract the list of image URLs from a JSON file (`release-$(uname -m).json`) while excluding the "lvms_operator" image.
 #    - `lvms_operator` image is excluded because it is not available upstream
-RUN if [ -n "$EMBED_CONTAINER_IMAGES" ] ; then \
+RUN if [ -n "${EMBED_CONTAINER_IMAGES}" ] ; then \
         echo "root:100000:65536" > /etc/subuid ; \
         echo "root:100000:65536" > /etc/subgid ; \
         for i in $(jq -r '.images | to_entries | map(select(.key != "lvms_operator")) | .[].value' "/usr/share/microshift/release/release-$(uname -m).json") ; do \
             skopeo copy --retry-times 3 --preserve-digests "docker://${i}" "containers-storage:${i}" ; \
         done ; \
-        if [ "$WITH_KINDNET" ]; then \
-            kindnetImage=$(jq -r '.images.kindnet' /usr/share/microshift/release/release-kindnet-$(uname -m).json) ; \
+        if [ "${WITH_KINDNET}" ]; then \
+            kindnetImage=$(jq -r '.images.kindnet' "/usr/share/microshift/release/release-kindnet-$(uname -m).json") ; \
             skopeo copy --retry-times 3 --preserve-digests "docker://${kindnetImage}" "containers-storage:${kindnetImage}" ; \
-            kubeproxyImage=$(jq -r '.images["kube-proxy"]' /usr/share/microshift/release/release-kube-proxy-$(uname -m).json) ; \
+            kubeproxyImage=$(jq -r '.images["kube-proxy"]' "/usr/share/microshift/release/release-kube-proxy-$(uname -m).json") ; \
             skopeo copy --retry-times 3 --preserve-digests "docker://${kubeproxyImage}" "containers-storage:${kubeproxyImage}" ; \
         fi && \
         rm -f /etc/subuid /etc/subgid ; \

--- a/packaging/microshift-cos9.Containerfile
+++ b/packaging/microshift-cos9.Containerfile
@@ -54,7 +54,7 @@ ARG OKD_CONFIG_SCRIPT=/tmp/configure.sh
 ARG USHIFT_RPM_REPO_NAME=microshift-local
 ARG USHIFT_RPM_REPO_PATH=/tmp/rpm-repo
 
-# Environment variables controlling the list of MicroShift components to build
+# Environment variables controlling the list of MicroShift components to install
 ENV WITH_KINDNET=${WITH_KINDNET:-1}
 ENV WITH_TOPOLVM=${WITH_TOPOLVM:-1}
 ENV WITH_OLM=${WITH_OLM:-0}

--- a/packaging/microshift-cos9.Containerfile
+++ b/packaging/microshift-cos9.Containerfile
@@ -1,16 +1,16 @@
 FROM quay.io/centos-bootc/centos-bootc:stream9 as builder
 
 ARG OKD_REPO=quay.io/okd/scos-release
-ARG OKD_VERSION_TAG=""
 ARG USHIFT_GIT_URL=https://github.com/openshift/microshift.git
-ARG USHIFT_BRANCH=main
 ENV USER=microshift
 ENV HOME=/microshift
 ARG REPO_DIR=/microshift/_output/rpmbuild/RPMS/
 ENV GOPATH=/microshift
 ENV GOMODCACHE=/microshift/.cache
 
-# Environment variables controlling the list of MicroShift components to build
+# Variables controlling the list of MicroShift components to build
+ARG OKD_VERSION_TAG
+ARG USHIFT_BRANCH=main
 ENV WITH_KINDNET=${WITH_KINDNET:-1}
 ENV WITH_TOPOLVM=${WITH_TOPOLVM:-1}
 ENV WITH_OLM=${WITH_OLM:-0}


### PR DESCRIPTION
Adds explicit RPM copy / install / uninstall instructions and refactors documentation to accomodate for separate build and run pages.

The build / run commands are now mostly `make` based for simplicity.