### PR TITLE
Add TopoLVM CSI backend manipulation to make rules

### DIFF
--- a/.github/workflows/build-rpms.yaml
+++ b/.github/workflows/build-rpms.yaml
@@ -88,17 +88,7 @@ jobs:
           # See https://github.com/microshift-io/microshift/blob/main/docs/run.md
           # for more information about the run process.
 
-          # Prepare the TopoLVM CSI backend on the host to be used by MicroShift when compiled with the default `WITH_TOPOLVM=1` built option.
-          LVM_DISK=/mnt/lvmdisk.image
-          VG_NAME=myvg1
-
-          sudo truncate --size=1G "${LVM_DISK}"
-          sudo losetup -f "${LVM_DISK}"
-
-          DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
-          sudo vgcreate -f -y "${VG_NAME}" "${DEVICE_NAME}"
-
-          # Run the MicroShift container.
+          # Run the MicroShift container
           make run && sleep 5
 
           # Wait until everything is up and running.

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ run:
 	sudo modprobe openvswitch
 	$(MAKE) _topolvm_create
 
-	VOL_OPTS=(--tty --volume /dev:/dev) ; \
+	VOL_OPTS="--tty --volume /dev:/dev" ; \
 	for device in input snd dri; do \
-		[ -d "/dev/$${device}" ] && VOL_OPTS+=("--tmpfs /dev/$${device}") ; \
+		[ -d "/dev/$${device}" ] && VOL_OPTS="$${VOL_OPTS} --tmpfs /dev/$${device}" ; \
 	done ; \
 	sudo podman run --privileged --rm -d \
 		--replace \
-		$${VOL_OPTS[@]} \
+		$${VOL_OPTS} \
 		--name "${USHIFT_IMAGE}" \
 		--hostname 127.0.0.1.nip.io \
 		"${USHIFT_IMAGE}"

--- a/docs/run.md
+++ b/docs/run.md
@@ -59,40 +59,22 @@ oc get pods -A
 
 ## MicroShift Bootc Image
 
-### Prerequisites
-
-#### TopoLVM Backend
-
-Prepare the TopoLVM CSI backend on the host to be used by MicroShift when compiled
-with the default `WITH_TOPOLVM=1` built option.
-
-```bash
-LVM_DISK=/var/db/lvmdisk.image
-VG_NAME=myvg1
-
-sudo truncate --size=20G "${LVM_DISK}"
-sudo losetup -f "${LVM_DISK}"
-
-DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
-sudo vgcreate -f -y "${VG_NAME}" "${DEVICE_NAME}"
-```
-
-#### OVN-K Configuration
-
-If OVN-K CNI driver is used (`WITH_KINDNET=0` non-default build option), the
-`openvswitch` module must be loaded on the host by running the following command.
-
-```bash
-sudo modprobe openvswitch
-```
-
 ### Start the Container
 
 Run the following command to start MicroShift inside a Bootc container.
 
+This step includes:
+* Loading the `openvswitch` module required when OVN-K CNI driver is used
+  when compiled with the non-default `WITH_KINDNET=0` build option.
+* Preparing a 1GB TopoLVM CSI backend on the host to be used by MicroShift when
+  compiled with the default `WITH_TOPOLVM=1` build option.
+
 ```bash
 make run
 ```
+
+Note: Use `LVM_VOLSIZE=<size>` make option to override the size of the created
+TopoLVM CSI backend (e.g. `LVM_VOLSIZE=10G`).
 
 ### Container Login
 
@@ -132,20 +114,16 @@ sudo dnf remove -y microshift*
 
 ### Bootc Containers
 
-Run the following commands to delete MicroShift Bootc container images.
+Run the following command to stop the MicroShift Bootc container and
+clean up the LVM volume used by the TopoLVM CSI backend.
 
 ```bash
 make clean
 ```
 
-Clean up the LVM volume used by the TopoLVM CSI backend.
+Run the following command to perform a full cleanup, including the
+MicroShift Bootc images.
 
 ```bash
-LVM_DISK=/var/db/lvmdisk.image
-VG_NAME=myvg1
-
-sudo vgremove -y "${VG_NAME}"
-DEVICE_NAME="$(sudo losetup -j "${LVM_DISK}" | cut -d: -f1)"
-[ -n "${DEVICE_NAME}" ] && sudo losetup -d "${DEVICE_NAME}"
-sudo rm -f "${LVM_DISK}"
+make clean-all
 ```

--- a/src/quickclean.sh
+++ b/src/quickclean.sh
@@ -18,8 +18,9 @@ podman rmi -f localhost/microshift-okd:latest || true
 
 # Remove the LVM disk
 if [ -f "${LVM_DISK}" ]; then
+    lvremove -y "${VG_NAME}" || true
     vgremove -y "${VG_NAME}" || true
     DEVICE_NAME="$(losetup -j "${LVM_DISK}" | cut -d: -f1)"
-    [ -n "${DEVICE_NAME}" ] && losetup -d "${DEVICE_NAME}"
+    [ -n "${DEVICE_NAME}" ] && losetup -d ${DEVICE_NAME}
     rm -rf "$(dirname "${LVM_DISK}")"
 fi

--- a/src/quickstart.sh
+++ b/src/quickstart.sh
@@ -74,14 +74,14 @@ function run_bootc_image() {
     # Mask the devices that may conflict with the host by sharing them on a
     # temporary file system. Note that a pseudo-TTY is also allocated to
     # prevent the container from using host consoles.
-    local vol_opts=(--tty --volume /dev:/dev)
+    local vol_opts="--tty --volume /dev:/dev"
     for device in input snd dri; do
-        [ -d "/dev/${device}" ] && vol_opts+=("--tmpfs /dev/${device}")
+        [ -d "/dev/${device}" ] && vol_opts="${vol_opts} --tmpfs /dev/${device}"
     done
-    # shellcheck disable=SC2068
+    # shellcheck disable=SC2086
     podman run --privileged --rm -d \
         --replace \
-        ${vol_opts[@]} \
+        ${vol_opts} \
         --name microshift-okd \
         --hostname 127.0.0.1.nip.io \
         "${image_name}"

--- a/src/quickstart.sh
+++ b/src/quickstart.sh
@@ -54,21 +54,35 @@ function prepare_lvm_disk() {
 
     mkdir -p "$(dirname "${lvm_disk}")"
     truncate --size=1G "${lvm_disk}"
-    losetup -f "${lvm_disk}"
 
-    local -r device_name="$(losetup -j "${lvm_disk}" | cut -d: -f1)"
+    local -r device_name="$(losetup --find --show --nooverlap "${lvm_disk}")"
     vgcreate -f -y "${vg_name}" "${device_name}"
 }
 
 function run_bootc_image() {
     local -r image_name="$1"
 
+    # Prerequisites for running the MicroShift container:
+    # - If the OVN-K CNI driver is used (`WITH_KINDNET=0` non-default build option),
+    #   the `openvswitch` module must be loaded on the host.
+    # - If the TopoLVM CSI driver is used (`WITH_TOPOLVM=1` default build option),
+    #   the /dev/dm-* device must be shared with the container.
     echo "Running '${image_name}'"
     modprobe openvswitch || true
+
+    # Share the /dev directory with the container to enable TopoLVM CSI driver.
+    # Mask the devices that may conflict with the host by sharing them on a
+    # temporary file system. Note that a pseudo-TTY is also allocated to
+    # prevent the container from using host consoles.
+    local vol_opts=(--tty --volume /dev:/dev)
+    for device in input snd dri; do
+        [ -d "/dev/${device}" ] && vol_opts+=("--tmpfs /dev/${device}")
+    done
+    # shellcheck disable=SC2068
     podman run --privileged --rm -d \
         --replace \
+        ${vol_opts[@]} \
         --name microshift-okd \
-  		--volume /dev:/dev:rslave \
         --hostname 127.0.0.1.nip.io \
         "${image_name}"
 


### PR DESCRIPTION
The following was tested:
* Local dev flows using make commands on a GNOME console
* Quick start and clean procedures on a GNOME console
* Running a [workflow](https://github.com/ggiguash/microshift-io/actions/runs/18216050712/job/51865402676) creating a release

Closes:
* #26 
* #28 
