### PR TITLE
Rename input `action` to `build` and prettify targets

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -10,14 +10,14 @@ inputs:
     description: OKD version tag from https://quay.io/repository/okd/scos-release?tab=tags
     required: true
     type: string
-  action:
+  build:
     type: choice
-    description: Action to perform
+    description: Types of artifacts to build
     required: true
     options:
-    - build-all
-    - build-rpms
-    - build-bootc-image
+    - all
+    - rpms
+    - bootc-image
 
 runs:
   using: "composite"
@@ -38,7 +38,7 @@ runs:
         sudo ln -s /mnt/containers /var/lib/containers
 
     - name: Build MicroShift RPMs
-      if:  inputs.action == 'build-rpms' || inputs.action == 'build-all'
+      if:  inputs.build == 'rpms' || inputs.build == 'all'
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/build.md
@@ -55,7 +55,7 @@ runs:
           RPM_OUTDIR=/mnt/rpms
 
     - name: Build MicroShift bootc container image
-      if:  inputs.action == 'build-bootc-image' || inputs.action == 'build-all'
+      if:  inputs.build == 'bootc-image' || inputs.build == 'all'
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/build.md
@@ -71,7 +71,7 @@ runs:
           OKD_VERSION_TAG=${{ inputs.okd-version-tag }}
 
     - name: Run a test to verify that MicroShift is functioning properly
-      if:  inputs.action == 'build-bootc-image' || inputs.action == 'build-all'
+      if:  inputs.build == 'bootc-image' || inputs.build == 'all'
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/run.md

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -38,7 +38,7 @@ runs:
         sudo ln -s /mnt/containers /var/lib/containers
 
     - name: Build MicroShift RPMs
-      if:  inputs.build == 'rpms' || inputs.build == 'all'
+      if: contains(fromJSON('["all", "rpms"]'), inputs.build)
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/build.md
@@ -55,7 +55,7 @@ runs:
           RPM_OUTDIR=/mnt/rpms
 
     - name: Build MicroShift bootc container image
-      if:  inputs.build == 'bootc-image' || inputs.build == 'all'
+      if: contains(fromJSON('["all", "bootc-image"]'), inputs.build)
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/build.md
@@ -71,7 +71,7 @@ runs:
           OKD_VERSION_TAG=${{ inputs.okd-version-tag }}
 
     - name: Run a test to verify that MicroShift is functioning properly
-      if:  inputs.build == 'bootc-image' || inputs.build == 'all'
+      if: contains(fromJSON('["all", "bootc-image"]'), inputs.build)
       shell: bash
       run: |
         # See https://github.com/microshift-io/microshift/blob/main/docs/run.md

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           ushift-branch: main
           okd-version-tag: ${{ steps.okd-version-tag.outputs.okd_version_tag }}
-          action: build-bootc-image
+          build: bootc-image
 
   quick-start-and-clean:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,14 @@ on:
         default: "4.19.0-okd-scos.19"
         description: OKD version tag from https://quay.io/repository/okd/scos-release?tab=tags
         type: string
-      action:
+      build:
         type: choice
-        description: Action to perform
-        default: build-all
+        description: Types of artifacts to build
+        default: all
         options:
-        - build-all
-        - build-rpms
-        - build-bootc-image
+        - all
+        - rpms
+        - bootc-image
 
 jobs:
   build:
@@ -39,12 +39,12 @@ jobs:
         with:
           ushift-branch: ${{ inputs.ushift-branch }}
           okd-version-tag: ${{ inputs.okd-version-tag }}
-          action: ${{ inputs.action }}
+          build: ${{ inputs.build }}
 
         # The release process consumes the RPMs and the container image
         # prepared by the build action.
       - name: Prepare the RPM archives
-        if:  inputs.action == 'build-rpms' || inputs.action == 'build-all'
+        if:  inputs.build == 'rpms' || inputs.build == 'all'
         shell: bash
         run : |
           # Archive sources separately from the RPMs
@@ -56,7 +56,7 @@ jobs:
           sudo tar zcvf /mnt/release/microshift-rpms-$(uname -m).tgz .
 
       - name: Release RPMs
-        if:  inputs.action == 'build-rpms' || inputs.action == 'build-all'
+        if:  inputs.build == 'rpms' || inputs.build == 'all'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }}
@@ -66,7 +66,7 @@ jobs:
           overwrite_files: true
 
       - name: Login to GitHub Container Registry
-        if:  inputs.action == 'build-bootc-image' || inputs.action == 'build-all'
+        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
         uses: redhat-actions/podman-login@v1
         with:
           registry: ghcr.io/${{ github.repository_owner }}
@@ -75,7 +75,7 @@ jobs:
           auth_file_path: /tmp/ghcr-auth.json
 
       - name: Publish Bootc image
-        if:  inputs.action == 'build-bootc-image' || inputs.action == 'build-all'
+        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
         shell: bash
         run: |
           sudo podman tag microshift-okd \
@@ -88,7 +88,7 @@ jobs:
           TAG=${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }} envsubst < .github/workflows/release.md > /tmp/release.md
 
       - name: Add release note for bootc image usage
-        if:  inputs.action == 'build-bootc-image' || inputs.action == 'build-all'
+        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
         # The release process consumes the RPMs and the container image
         # prepared by the build action.
       - name: Prepare the RPM archives
-        if:  inputs.build == 'rpms' || inputs.build == 'all'
+        if: contains(fromJSON('["all", "rpms"]'), inputs.build)
         shell: bash
         run : |
           # Archive sources separately from the RPMs
@@ -56,7 +56,7 @@ jobs:
           sudo tar zcvf /mnt/release/microshift-rpms-$(uname -m).tgz .
 
       - name: Release RPMs
-        if:  inputs.build == 'rpms' || inputs.build == 'all'
+        if: contains(fromJSON('["all", "rpms"]'), inputs.build)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }}
@@ -66,7 +66,7 @@ jobs:
           overwrite_files: true
 
       - name: Login to GitHub Container Registry
-        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
+        if: contains(fromJSON('["all", "bootc-image"]'), inputs.build)
         uses: redhat-actions/podman-login@v1
         with:
           registry: ghcr.io/${{ github.repository_owner }}
@@ -75,7 +75,7 @@ jobs:
           auth_file_path: /tmp/ghcr-auth.json
 
       - name: Publish Bootc image
-        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
+        if: contains(fromJSON('["all", "bootc-image"]'), inputs.build)
         shell: bash
         run: |
           sudo podman tag microshift-okd \
@@ -88,7 +88,7 @@ jobs:
           TAG=${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }} envsubst < .github/workflows/release.md > /tmp/release.md
 
       - name: Add release note for bootc image usage
-        if:  inputs.build == 'bootc-image' || inputs.build == 'all'
+        if: contains(fromJSON('["all", "bootc-image"]'), inputs.build)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ushift-branch }}-${{ inputs.okd-version-tag }}


### PR DESCRIPTION
Because building was extracted into its own action, we can rename the input to be... nicer.
The `contains()` pattern was based on [the example in the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#example-matching-an-array-of-strings).