### PR TITLE
Sos report should generate unique file names

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -125,7 +125,6 @@ runs:
 
         # Wait until the MicroShift service is ready and healthy
         make run-ready
-        exit 1
         make run-healthy
 
         # Stop the MicroShift container


### PR DESCRIPTION
Resolves #77 

The artifact name is now unique per job run.
```
Artifact sosreport-microshift-okd-centos10-bootc-test-x86_64-18553167661.zip successfully finalized. Artifact ID 4285421730
Artifact sosreport-microshift-okd-centos10-bootc-test-x86_64-18553167661 has been successfully uploaded! Final size is 7474521 bytes. Artifact ID is 4285421730
Artifact download URL: https://github.com/microshift-io/microshift/actions/runs/18553167661/artifacts/4285421730
```

See the following runs with simulated failure as an example:
- https://github.com/microshift-io/microshift/actions/runs/18553167661/job/52884534271
- https://github.com/microshift-io/microshift/actions/runs/18553167661/job/52884534220
- https://github.com/microshift-io/microshift/actions/runs/18553167661/job/52884534168