### PR TITLE
Add anonymous volume backend for /var/lib/kubelet mount to enable idmap support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,6 @@ image:
     	--env EMBED_CONTAINER_IMAGES="${EMBED_CONTAINER_IMAGES}" \
         -f packaging/microshift-runner.Containerfile .
 
-# Notes:
-# - An isolated network is created if the ISOLATED_NETWORK environment variable is set
-# - The /dev directory is shared with the container to enable TopoLVM CSI driver,
-#   masking the devices that may conflict with the host
-# - The containers storage is mounted on a tmpfs to avoid usage of fuse-overlayfs,
-#   which is less efficient than the default driver
 .PHONY: run
 run:
 	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} ./src/cluster_manager.sh create

--- a/packaging/microshift-runner.Containerfile
+++ b/packaging/microshift-runner.Containerfile
@@ -58,3 +58,7 @@ RUN if [ "${EMBED_CONTAINER_IMAGES}" = "1" ] ; then \
 # shared as required by OVN images
 COPY --from=builder ${BUILDER_RSHARED_SERVICE} /usr/lib/systemd/system/microshift-make-rshared.service
 RUN systemctl enable microshift-make-rshared.service
+
+# The /var directory is shared with the container as an anonymous volume to enable
+# idmap mounts under /var/lib/kubelet for containers using 'hostUsers: false'
+VOLUME ["/var"]


### PR DESCRIPTION
Resolves #134 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added idmap mount support in the container image to enable hostless user mounts.

* **Bug Fixes**
  * Cluster teardown now removes associated container anonymous volumes during destruction.

* **Documentation**
  * Removed several outdated descriptive comments to streamline build/run documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->