### PR TITLE
Fall back to Fedora 42 in builders.yaml

### DIFF
--- a/.github/workflows/builders.yaml
+++ b/.github/workflows/builders.yaml
@@ -67,7 +67,7 @@ jobs:
           ushift-branch: main
           okd-version-tag: ${{ steps.detect-okd-version.outputs.okd-version-tag }}
           bootc-image-url: registry.fedoraproject.org/fedora-bootc
-          bootc-image-tag: latest
+          bootc-image-tag: 42
           build: bootc-image
           node-count: 2
 


### PR DESCRIPTION
This is required until #139 is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to pin bootc image version to version 42 for improved build consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->