### PR TITLE
ISSUE-149: added make env mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ EMBED_CONTAINER_IMAGES ?= 0
 # Options used in the 'run' target
 LVM_VOLSIZE ?= 1G
 ISOLATED_NETWORK ?= 0
-EXPOSE_KUBEAPI_PORT ?= 0
+EXPOSE_KUBEAPI_PORT ?= 1
 
 # Internal variables
 SHELL := /bin/bash
@@ -48,7 +48,7 @@ VG_NAME := myvg1
 #
 .PHONY: all
 all:
-	@echo "make <rpm | srpm | image | run | add-node | start | stop | clean | check | env>"
+	@echo "make <rpm | srpm | image | run | add-node | start | stop | clean | check | env [CMD=command]>"
 	@echo "   rpm:       	build the MicroShift RPMs"
 	@echo "   srpm:      	build the MicroShift SRPM"
 	@echo "   image:     	build the MicroShift bootc container image"
@@ -58,8 +58,8 @@ all:
 	@echo "   stop:      	stop the MicroShift cluster"
 	@echo "   clean:     	clean up the MicroShift cluster and the LVM backend"
 	@echo "   check:     	run the presubmit checks"
-	@echo "   env:       	create a shell environment with kubeconfig from remote POD"
-	@echo "               	use 'make env CMD=\"oc get pods -A\"' to run one-liner commands"
+	@echo "   env:       	start a shell with MicroShift kubeconfig environment"
+	@echo "   env CMD=...:  run a command in MicroShift kubeconfig environment"
 	@echo ""
 	@echo "Sub-targets:"
 	@echo "   rpm-to-deb:	convert the MicroShift RPMs to Debian packages"
@@ -141,11 +141,11 @@ run:
 
 .PHONY: add-node
 add-node:
-	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} EXPOSE_KUBEAPI_PORT=${EXPOSE_KUBEAPI_PORT} ./src/cluster_manager.sh add-node
+	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} EXPOSE_KUBEAPI_PORT=0 ./src/cluster_manager.sh add-node
 
 .PHONY: start
 start:
-	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} ./src/cluster_manager.sh start
+	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} EXPOSE_KUBEAPI_PORT=0 ./src/cluster_manager.sh start
 
 .PHONY: stop
 stop:
@@ -178,8 +178,8 @@ run-status:
 	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} ./src/cluster_manager.sh status
 
 .PHONY: env
-env:
-	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} ./src/cluster_manager.sh env "" "${CMD}"
+env: run-ready
+	@USHIFT_IMAGE=${USHIFT_IMAGE} ISOLATED_NETWORK=${ISOLATED_NETWORK} LVM_DISK=${LVM_DISK} LVM_VOLSIZE=${LVM_VOLSIZE} VG_NAME=${VG_NAME} EXPOSE_KUBEAPI_PORT=1 ./src/cluster_manager.sh env "${CMD}"
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
this PR Resolves #149

Interactive shell (no command):
   `make env`

One-liner command (using CMD variable):
   ```
   make env CMD="oc get pods -A"   
   make env CMD="kubectl get nodes"   
   make env CMD="oc get pods -A | grep running"
   ```

The implementation:
- Uses the default pod name (microshift-okd-1) when no pod is specified
- Executes the command in the environment and exits if CMD is provided
- Starts an interactive shell if CMD is not provided
- Handles commands with multiple words and pipes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "env" command/target to open a ready cluster environment for running a command or interactive shell; prepares KUBECONFIG and verifies API access.

* **New Options**
  * Added environment controls: EXPOSE_KUBEAPI_PORT (on by default), API_SERVER_PORT, and EXTRA_CONFIG to control API exposure and extra config injection.

* **Documentation**
  * Help text updated to document the new env target and CMD usage; run/start/add-node propagate the API exposure setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->