### PR TITLE
Add ufw route allowance from specific subnet

### DIFF
--- a/src/deb/install.sh
+++ b/src/deb/install.sh
@@ -95,6 +95,7 @@ function install_prereqs() {
 function install_firewall() {
     apt-get install -y -q ufw
 
+    ufw route allow from 10.42.0.0/16
     ufw allow from 10.42.0.0/16
     ufw allow from 169.254.169.1
     ufw allow ssh


### PR DESCRIPTION
this will allow routed traffic from pod network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated firewall configuration during installation to include a routing rule for the 10.42.0.0/16 subnet, adjusting the order of firewall setup steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->