### PR TITLE
Implement the latest tag expansion in the CNCF workflow

### DIFF
--- a/.github/workflows/cncf-conformance.yaml
+++ b/.github/workflows/cncf-conformance.yaml
@@ -50,7 +50,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          IMAGE="${{ env.REGISTRY }}/microshift:${{ env.VERSION }}"
+          # Update the 'latest' tag to the latest released version from the
+          # MicroShift GitHub repository.
+          # Note: To test images from other repositories, override the 'VERSION'
+          # and 'REGISTRY' settings to point to a custom multi-arch manifest.
+          TAG="${{ env.VERSION }}"
+          if [ "${TAG}" = "latest" ] ; then
+            TAG="$(curl -s --max-time 60 "https://api.github.com/repos/microshift-io/microshift/releases/latest" | jq -r .tag_name)"
+            if [ -z "${TAG}" ] || [ "${TAG}" = "null" ] ; then
+              echo "ERROR: Could not determine the latest release tag from GitHub"
+              exit 1
+            fi
+          fi
+
+          IMAGE="${{ env.REGISTRY }}/microshift:${TAG}"
 
           echo "Pulling ${IMAGE}"
           sudo podman pull "${IMAGE}"


### PR DESCRIPTION
Fixes #127

In [this comment](https://github.com/microshift-io/microshift/pull/162#discussion_r2645367516), I wrongly suggested not to implement the code for the `latest` tag expansion. 

P.S. We used `latest` tags in the beginning, but then stopped. There was a left-over old image that misled me into thinking the expansion is not necessary. I removed that image to avoid similar mistakes in the future.

```
$ podman pull ghcr.io/microshift-io/microshift:latest
Trying to pull ghcr.io/microshift-io/microshift:latest...
Error: initializing source docker://ghcr.io/microshift-io/microshift:latest: reading manifest latest in ghcr.io/microshift-io/microshift: manifest unknown
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dynamic version detection in the conformance testing workflow.
  * Enhanced error handling for version resolution to ensure reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->