### PR TITLE
Disable bootc-publish-rhsm-facts service if it exists

### DIFF
--- a/packaging/bootc.Containerfile
+++ b/packaging/bootc.Containerfile
@@ -66,3 +66,8 @@ RUN systemctl enable microshift-make-rshared.service
 # The /var directory is shared with the container as an anonymous volume to enable
 # idmap mounts under /var/lib/kubelet for containers using 'hostUsers: false'
 VOLUME ["/var"]
+
+# Disable the bootc-publish-rhsm-facts.service if it exists
+RUN if systemctl list-unit-files bootc-publish-rhsm-facts.service >/dev/null 2>&1 ; then \
+        systemctl disable bootc-publish-rhsm-facts.service ; \
+    fi


### PR DESCRIPTION
Resolves #187 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * During container image build, added a step to detect and disable an optional system service so it won’t be enabled in the produced images. This prevents unwanted service activation at runtime and keeps images clean.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->