### PR TITLE
Fix release procedure to use CentOS Stream9 for 4.20 and older versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,13 +43,33 @@ jobs:
         id: detect-okd-version
         uses: ./.github/actions/okd-version
 
+      - name: Determine bootc stream version
+        id: set-bootc-image-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -x
+
+          ref="${{ inputs.ushift-gitref }}"
+          tag="stream10"
+
+          # Prior to version 4.21, crio depends on containernetworking-plugins
+          # which is not available in CentOS Stream 10
+          if [[ "${ref}" =~ release-4\.([0-9]+) ]]; then
+            yver="${BASH_REMATCH[1]}"
+            if [ "${yver}" -lt 21 ]; then
+              tag="stream9"
+            fi
+          fi
+          echo "bootc-image-tag=${tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Run the build action
         uses: ./.github/actions/build
         with:
           ushift-gitref: ${{ inputs.ushift-gitref }}
           okd-version-tag: ${{ inputs.okd-version-tag != 'latest' && inputs.okd-version-tag || steps.detect-okd-version.outputs.okd-version-tag }}
           bootc-image-url: quay.io/centos-bootc/centos-bootc
-          bootc-image-tag: stream10
+          bootc-image-tag: ${{ steps.set-bootc-image-tag.outputs.bootc-image-tag }}
           build: ${{ inputs.build }}
 
       # Test the local container image with the quick start and clean procedures


### PR DESCRIPTION
Resolves #191

Successful test of the release flow in [this build](https://github.com/ggiguash/microshift-io/actions/runs/20742652661).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to dynamically determine build image tags based on version parameters instead of using a fixed configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->