### PR TITLE
Build Multus RPM

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: Use OVN-K networking
     required: false
     default: 0
+  with-multus:
+    description: Enable Multus CNI
+    required: false
+    default: 0
   node-count:
     description: Number of nodes in the MicroShift cluster
     required: false
@@ -76,6 +80,7 @@ runs:
         make_opts=()
         [ "${{ inputs.isolated-network }}" = "1" ] && make_opts+=("EMBED_CONTAINER_IMAGES=1")
         [ "${{ inputs.ovnk-networking }}"  = "1" ] && make_opts+=("WITH_KINDNET=0")
+        [ "${{ inputs.with-multus }}"     = "1" ] && make_opts+=("WITH_MULTUS=1")
 
         make image \
           BOOTC_IMAGE_URL="${{ inputs.bootc-image-url }}" \

--- a/.github/workflows/builders.yaml
+++ b/.github/workflows/builders.yaml
@@ -93,9 +93,15 @@ jobs:
           - name: kindnet
             runner: ubuntu-24.04
             ovnk-networking: 0
+            with-multus: 0
           - name: ovnk
             runner: ubuntu-24.04
             ovnk-networking: 1
+            with-multus: 0
+          - name: ovnk-multus
+            runner: ubuntu-24.04
+            ovnk-networking: 1
+            with-multus: 1
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out MicroShift upstream repository
@@ -112,3 +118,4 @@ jobs:
           okd-version-tag: ${{ steps.detect-okd-version.outputs.okd-version-tag }}
           isolated-network: 1
           ovnk-networking: ${{ matrix.ovnk-networking }}
+          with-multus: ${{ matrix.with-multus }}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ BOOTC_IMAGE_TAG ?= stream9
 WITH_KINDNET ?= 1
 WITH_TOPOLVM ?= 1
 WITH_OLM ?= 0
+WITH_MULTUS ?= 0
 EMBED_CONTAINER_IMAGES ?= 0
 
 # Options used in the 'run' target
@@ -130,6 +131,7 @@ image:
     	--env WITH_KINDNET="${WITH_KINDNET}" \
     	--env WITH_TOPOLVM="${WITH_TOPOLVM}" \
     	--env WITH_OLM="${WITH_OLM}" \
+    	--env WITH_MULTUS="${WITH_MULTUS}" \
     	--env EMBED_CONTAINER_IMAGES="${EMBED_CONTAINER_IMAGES}" \
         -f packaging/bootc.Containerfile .
 

--- a/packaging/bootc.Containerfile
+++ b/packaging/bootc.Containerfile
@@ -18,6 +18,7 @@ ARG BUILDER_RSHARED_SERVICE=/home/microshift/microshift/packaging/imagemode/syst
 ENV WITH_KINDNET=${WITH_KINDNET:-1}
 ENV WITH_TOPOLVM=${WITH_TOPOLVM:-1}
 ENV WITH_OLM=${WITH_OLM:-0}
+ENV WITH_MULTUS=${WITH_MULTUS:-0}
 ENV EMBED_CONTAINER_IMAGES=${EMBED_CONTAINER_IMAGES:-0}
 
 # Run repository configuration script, install MicroShift and cleanup
@@ -35,6 +36,9 @@ RUN ${REPO_CONFIG_SCRIPT} -create ${USHIFT_RPM_REPO_PATH} && \
     fi && \
     if [ "${WITH_OLM}" = "1" ] ; then \
         dnf install -y microshift-olm microshift-olm-release-info ; \
+    fi && \
+    if [ "${WITH_MULTUS}" = "1" ] ; then \
+        dnf install -y microshift-multus microshift-multus-release-info ; \
     fi && \
     ${REPO_CONFIG_SCRIPT} -delete && \
     rm -vf  ${REPO_CONFIG_SCRIPT} && \

--- a/packaging/srpm.Containerfile
+++ b/packaging/srpm.Containerfile
@@ -58,7 +58,9 @@ COPY ./src/topolvm/greenboot/ ./packaging/greenboot/
 COPY ./src/topolvm/release/ ./assets/optional/topolvm/
 
 RUN ARCH="x86_64" "${USHIFT_PREBUILD_SCRIPT}" --replace-kindnet "${OKD_RELEASE_IMAGE_X86_64}" "${OKD_VERSION_TAG}" && \
-    ARCH="aarch64" "${USHIFT_PREBUILD_SCRIPT}" --replace-kindnet "${OKD_RELEASE_IMAGE_AARCH64}" "${OKD_VERSION_TAG}"
+    ARCH="aarch64" "${USHIFT_PREBUILD_SCRIPT}" --replace-kindnet "${OKD_RELEASE_IMAGE_AARCH64}" "${OKD_VERSION_TAG}" && \
+    ARCH="x86_64" "${USHIFT_PREBUILD_SCRIPT}" --replace-multus "${OKD_RELEASE_IMAGE_X86_64}" "${OKD_VERSION_TAG}" && \
+    ARCH="aarch64" "${USHIFT_PREBUILD_SCRIPT}" --replace-multus "${OKD_RELEASE_IMAGE_AARCH64}" "${OKD_VERSION_TAG}"
 
 COPY --chmod=755 ./src/image/modify-spec.py ${USHIFT_MODIFY_SPEC_SCRIPT}
 # Disable the RPM and SRPM checks in the make-rpm.sh script

--- a/src/image/modify-spec.py
+++ b/src/image/modify-spec.py
@@ -12,7 +12,6 @@ from itertools import product
 
 # Subpackages to remove
 pkgs_to_remove = [
-    'multus',
     'low-latency',
     'gateway-api',
     'ai-model-serving',

--- a/src/image/prebuild.sh
+++ b/src/image/prebuild.sh
@@ -168,6 +168,36 @@ replace_kindnet_assets() {
     mv "${temp_json}" "${MICROSHIFT_ROOT}/assets/optional/kube-proxy/release-kube-proxy-${ARCH}.json"
 }
 
+replace_multus_assets() {
+    local -r okd_url=$1
+    local -r okd_releaseTag=$2
+    local -r temp_json="$(mktemp "/tmp/release-multus-${ARCH}.XXXXX.json")"
+
+    # Install the yq tool
+    "${MICROSHIFT_ROOT}"/scripts/fetch_tools.sh yq
+
+    local -r multus_release_json="${MICROSHIFT_ROOT}/assets/components/multus/release-multus-${ARCH}.json"
+    local -r kustomization_arch_file="${MICROSHIFT_ROOT}/assets/components/multus/kustomization.${ARCH}.yaml"
+
+    for container in multus-cni-microshift containernetworking-plugins-microshift ; do
+        local image_with_hash
+        image_with_hash=$(oc_release_info "${okd_url}" "${okd_releaseTag}" "${container}")
+        echo "[${ARCH}] Replacing '${container}' with '${image_with_hash}'"
+        local image_name="${image_with_hash%%@*}"
+        local image_hash="${image_with_hash##*@}"
+
+        # Update the kustomization file with the new image name and digest
+        "${MICROSHIFT_ROOT}"/_output/bin/yq eval \
+            ".images[] |= select(.name == \"${container}\") |= (.newName = \"${image_name}\" | .digest = \"${image_hash}\")" \
+            -i "${kustomization_arch_file}"
+
+        # Update the release JSON file
+        jq --arg container "${container}" --arg img "${image_with_hash}" \
+            '.images[$container] = $img' "${multus_release_json}" >"${temp_json}"
+        mv "${temp_json}" "${multus_release_json}"
+    done
+}
+
 fix_rpm_spec() {
     # Fix the RPM spec by removing the microshift-networking package hard dependency
     sed -i 's/Requires: microshift-networking/Recommends: microshift-networking/' "${MICROSHIFT_ROOT}/packaging/rpm/microshift.spec"
@@ -178,6 +208,7 @@ usage() {
     echo "$(basename "$0") --verify          OKD_URL RELEASE_TAG    verify OKD upstream release"
     echo "$(basename "$0") --replace         OKD_URL RELEASE_TAG    replace MicroShift assets with OKD upstream images"
     echo "$(basename "$0") --replace-kindnet OKD_URL RELEASE_TAG    replace Kindnet assets with OKD upstream images"
+    echo "$(basename "$0") --replace-multus  OKD_URL RELEASE_TAG    replace Multus assets with OKD upstream images"
     exit 1
 }
 
@@ -198,6 +229,10 @@ case "$1" in
 --replace-kindnet)
     verify_okd_release     "$2" "$3"
     replace_kindnet_assets "$2" "$3"
+    ;;
+--replace-multus)
+    verify_okd_release    "$2" "$3"
+    replace_multus_assets "$2" "$3"
     ;;
 --verify)
     verify_okd_release "$2" "$3"

--- a/src/okd/build_images.sh
+++ b/src/okd/build_images.sh
@@ -263,6 +263,32 @@ ovn_kubernetes_microshift_image() {
   podman build --platform "linux/${TARGET_ARCH}" -t "${images[ovn-kubernetes-microshift]}" -f "${dockerfile_microshift_path}" .
 }
 
+# Function to handle multus-cni-microshift image repository
+multus_cni_microshift_image() {
+  local -r repo_url="https://github.com/openshift/multus-cni"
+  local -r dockerfile_path="Dockerfile.microshift"
+  local -r repo="${WORKDIR}/$(basename "${repo_url}")"
+
+  git_clone_repo "${repo_url}" "${OCP_BRANCH}" "${repo}"
+  sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang|FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang|' "${dockerfile_path}"
+  sed -i "s|^FROM registry.ci.openshift.org/ocp/.*:base-rhel9|FROM ${images[base]}|" "${dockerfile_path}"
+
+  podman build --platform "linux/${TARGET_ARCH}" -t "${images[multus-cni-microshift]}" -f "${dockerfile_path}" .
+}
+
+# Function to handle containernetworking-plugins-microshift image repository
+containernetworking_plugins_microshift_image() {
+  local -r repo_url="https://github.com/openshift/containernetworking-plugins"
+  local -r dockerfile_path="Dockerfile.microshift"
+  local -r repo="${WORKDIR}/$(basename "${repo_url}")"
+
+  git_clone_repo "${repo_url}" "${OCP_BRANCH}" "${repo}"
+  sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang|FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang|' "${dockerfile_path}"
+  sed -i "s|^FROM registry.ci.openshift.org/ocp/.*:base-rhel9|FROM ${images[base]}|" "${dockerfile_path}"
+
+  podman build --platform "linux/${TARGET_ARCH}" -t "${images[containernetworking-plugins-microshift]}" -f "${dockerfile_path}" .
+}
+
 # Run all the image creation procedures
 create_images() {
   base_image
@@ -275,6 +301,8 @@ create_images() {
   cli_image
   service_ca_operator_image
   operator_lifecycle_manager_image
+  multus_cni_microshift_image
+  containernetworking_plugins_microshift_image
   # ovn_kubernetes_microshift_image
 }
 
@@ -336,6 +364,8 @@ create_new_okd_release() {
       "service-ca-operator=${images_sha[service-ca-operator]}" \
       "operator-lifecycle-manager=${images_sha[operator-lifecycle-manager]}" \
       "operator-registry=${images_sha[operator-registry]}" \
+      "multus-cni-microshift=${images_sha[multus-cni-microshift]}" \
+      "containernetworking-plugins-microshift=${images_sha[containernetworking-plugins-microshift]}" \
       --to-image "${OKD_RELEASE_IMAGE}"
 
       # "ovn-kubernetes-base=${images_sha[ovn-kubernetes-base]}" \
@@ -518,6 +548,8 @@ images=(
     [service-ca-operator]="${TARGET_REGISTRY}/service-ca-operator:${OKD_VERSION}-${TARGET_ARCH}"
     [operator-lifecycle-manager]="${TARGET_REGISTRY}/operator-lifecycle-manager:${OKD_VERSION}-${TARGET_ARCH}"
     [operator-registry]="${TARGET_REGISTRY}/operator-registry:${OKD_VERSION}-${TARGET_ARCH}"
+    [multus-cni-microshift]="${TARGET_REGISTRY}/multus-cni-microshift:${OKD_VERSION}-${TARGET_ARCH}"
+    [containernetworking-plugins-microshift]="${TARGET_REGISTRY}/containernetworking-plugins-microshift:${OKD_VERSION}-${TARGET_ARCH}"
     # [ovn-kubernetes-base]="${TARGET_REGISTRY}/ovn-kubernetes-base:${OKD_VERSION}-${TARGET_ARCH}"
     # [ovn-kubernetes-microshift]="${TARGET_REGISTRY}/ovn-kubernetes-microshift:${OKD_VERSION}-${TARGET_ARCH}"
 )

--- a/src/okd/build_images.sh
+++ b/src/okd/build_images.sh
@@ -212,6 +212,21 @@ cli_image() {
   podman build --platform "linux/${TARGET_ARCH}" -t "${images[cli]}" -f "${dockerfile_path}" .
 }
 
+# Function to handle cli-artifacts-image repository (same repo as cli)
+cli_artifacts_image() {
+  local -r dockerfile_path="images/cli-artifacts/Dockerfile.rhel"
+  local -r repo="${WORKDIR}/oc"
+
+  # Reuse the already cloned oc repository from cli_image()
+  cd "${repo}" || { echo "Failed to access oc repository directory"; return 1; }
+  sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang|FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang|' "${dockerfile_path}"
+  sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang|FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang|' "${dockerfile_path}"
+  sed -i "s|^FROM registry.ci.openshift.org/ocp/.*:base-rhel9|FROM ${images[base]}|" "${dockerfile_path}"
+  sed -i "s|^FROM registry.ci.openshift.org/ocp/.*:cli|FROM ${images[cli]}|" "${dockerfile_path}"
+
+  podman build --platform "linux/${TARGET_ARCH}" -t "${images[cli-artifacts]}" -f "${dockerfile_path}" .
+}
+
 # Function to handle service-ca-operator-image repository
 service_ca_operator_image() {
   local -r repo_url="https://github.com/openshift/service-ca-operator"
@@ -299,6 +314,7 @@ create_images() {
   kube_rbac_proxy_image
   pod_image
   cli_image
+  cli_artifacts_image
   service_ca_operator_image
   operator_lifecycle_manager_image
   multus_cni_microshift_image
@@ -355,6 +371,7 @@ create_new_okd_release() {
   oc adm release new --from-release "quay.io/okd/scos-release:${OKD_VERSION}" \
       --keep-manifest-list \
       "cli=${images_sha[cli]}" \
+      "cli-artifacts=${images_sha[cli-artifacts]}" \
       ${haproxy_router_image} \
       "kube-proxy=${images_sha[kube-proxy]}" \
       "coredns=${images_sha[coredns]}" \
@@ -538,6 +555,7 @@ fi
 images=(
     [base]="${TARGET_REGISTRY}/scos-${OKD_VERSION}:base-stream9-${TARGET_ARCH}"
     [cli]="${TARGET_REGISTRY}/cli:${OKD_VERSION}-${TARGET_ARCH}"
+    [cli-artifacts]="${TARGET_REGISTRY}/cli-artifacts:${OKD_VERSION}-${TARGET_ARCH}"
     [haproxy-router-base]="${TARGET_REGISTRY}/haproxy-router-base:${OKD_VERSION}-${TARGET_ARCH}"
     [haproxy-router]="${TARGET_REGISTRY}/haproxy-router:${OKD_VERSION}-${TARGET_ARCH}"
     [kube-proxy]="${TARGET_REGISTRY}/kube-proxy:${OKD_VERSION}-${TARGET_ARCH}"


### PR DESCRIPTION
Closes #202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Multus networking component enabled via a build-time flag.
  * Container images and packages can include Multus when enabled.
  * New Multus-related images are built and integrated into release generation.

* **Chores**
  * Build tooling and CI workflow now support toggling Multus via build inputs/matrix. 

* **Maintenance**
  * Prebuild tooling can replace Multus assets from an OKD release; Multus is no longer removed by downstream package cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->