### PR TITLE
Fix OKD image build procedure

### DIFF
--- a/.github/actions/prebuild/action.yaml
+++ b/.github/actions/prebuild/action.yaml
@@ -40,7 +40,7 @@ runs:
         if [ "$(uname -m)" == "aarch64" ] ; then
           ocp_client="openshift-client-linux-arm64-rhel9.tar.gz"
         fi
-        curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${ocp_client} -o /tmp/${ocp_client}
+        curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${ocp_client} -o /tmp/${ocp_client}
         sudo tar xvf /tmp/${ocp_client} -C /usr/bin
         rm -f /tmp/${ocp_client}
 

--- a/.github/workflows/cncf-conformance.yaml
+++ b/.github/workflows/cncf-conformance.yaml
@@ -57,7 +57,7 @@ jobs:
           # and 'REGISTRY' settings to point to a custom multi-arch manifest.
           TAG="${{ env.VERSION }}"
           if [ "${TAG}" = "latest" ] ; then
-            TAG="$(curl -s --max-time 60 "https://api.github.com/repos/microshift-io/microshift/releases/latest" | jq -r .tag_name)"
+            TAG="$(curl -fsSL --max-time 60 "https://api.github.com/repos/microshift-io/microshift/releases/latest" | jq -r .tag_name)"
             if [ -z "${TAG}" ] || [ "${TAG}" = "null" ] ; then
               echo "ERROR: Could not determine the latest release tag from GitHub"
               exit 1

--- a/packaging/srpm.Containerfile
+++ b/packaging/srpm.Containerfile
@@ -45,7 +45,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 RUN [ "$(uname -m)" = "aarch64" ] && ARCH="-arm64" || ARCH="" ; \
     OKD_CLIENT_URL="https://github.com/okd-project/okd/releases/download/${OKD_VERSION_TAG}/openshift-client-linux${ARCH}-${OKD_VERSION_TAG}.tar.gz" && \
     echo "OKD_CLIENT_URL: ${OKD_CLIENT_URL}" && \
-    curl -L --retry 5 -o /tmp/okd-client.tar.gz "${OKD_CLIENT_URL}" && \
+    curl -fsSL --retry 5 -o /tmp/okd-client.tar.gz "${OKD_CLIENT_URL}" && \
     tar -xzf /tmp/okd-client.tar.gz -C /usr/local/bin/ && \
     rm -rf /tmp/okd-client.tar.gz
 

--- a/src/copr/cni/build.sh
+++ b/src/copr/cni/build.sh
@@ -49,8 +49,8 @@ cp "${_scriptdir}/containernetworking-plugins.spec" "${temp_dir}/"
 pushd "${temp_dir}" >/dev/null
 
 echo "### Downloading the CNI plugins x86_64 and aarch64 releases for ${version}"
-curl -L -o amd64.tgz "https://github.com/containernetworking/plugins/releases/download/v${version}/cni-plugins-linux-amd64-v${version}.tgz"
-curl -L -o arm64.tgz "https://github.com/containernetworking/plugins/releases/download/v${version}/cni-plugins-linux-arm64-v${version}.tgz"
+curl -fsSL -o amd64.tgz "https://github.com/containernetworking/plugins/releases/download/v${version}/cni-plugins-linux-amd64-v${version}.tgz"
+curl -fsSL -o arm64.tgz "https://github.com/containernetworking/plugins/releases/download/v${version}/cni-plugins-linux-arm64-v${version}.tgz"
 
 mkdir -p "containernetworking-plugins-${version}"/{x86_64,aarch64}
 

--- a/src/kindnet/generate_manifests.sh
+++ b/src/kindnet/generate_manifests.sh
@@ -22,7 +22,7 @@ CLUSTER_CIDR="10.42.0.0/16"
 get_kindnet_image_info() {
     echo "Fetching latest kindnet image info..."
     # Get the latest kindnet tag from Docker Hub
-    KINDNET_LATEST_TAG="$(curl -f -s 'https://registry.hub.docker.com/v2/repositories/kindest/kindnetd/tags?page_size=1&ordering=last_updated' | jq -r '.results[0].name')"
+    KINDNET_LATEST_TAG="$(curl -fsSL 'https://registry.hub.docker.com/v2/repositories/kindest/kindnetd/tags?page_size=1&ordering=last_updated' | jq -r '.results[0].name')"
     if [ -z "${KINDNET_LATEST_TAG}" ] || [ "${KINDNET_LATEST_TAG}" = "null" ]; then
         echo "Error: Failed to retrieve latest kindnet tag from Docker Hub"
         exit 1
@@ -30,7 +30,7 @@ get_kindnet_image_info() {
     echo "Latest kindnet tag: ${KINDNET_LATEST_TAG}"
 
     # Get the manifest list to extract architecture-specific digests
-    KINDNET_MANIFEST="$(curl -f -s "https://registry.hub.docker.com/v2/repositories/kindest/kindnetd/tags/${KINDNET_LATEST_TAG}")"
+    KINDNET_MANIFEST="$(curl -fsSL "https://registry.hub.docker.com/v2/repositories/kindest/kindnetd/tags/${KINDNET_LATEST_TAG}")"
     KINDNET_SHA256_AARCH64="sha256:$(echo "${KINDNET_MANIFEST}" | jq -r '.images[] | select(.architecture == "arm64") | .digest' | sed 's/sha256://')"
     KINDNET_SHA256_X86_64="sha256:$(echo "${KINDNET_MANIFEST}" | jq -r '.images[] | select(.architecture == "amd64") | .digest' | sed 's/sha256://')"
 
@@ -57,7 +57,7 @@ get_kube_proxy_image_info() {
 
     # Fetch all tags from registry.k8s.io and get the latest stable version
     # (excludes alpha, beta, rc versions)
-    KUBE_PROXY_LATEST_TAG="$(curl -sL "https://registry.k8s.io/v2/kube-proxy/tags/list" | \
+    KUBE_PROXY_LATEST_TAG="$(curl -fsSL "https://registry.k8s.io/v2/kube-proxy/tags/list" | \
         jq -r '.tags[]' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
     if [ -z "${KUBE_PROXY_LATEST_TAG}" ]; then
         echo "Error: No kube-proxy tags found"
@@ -67,7 +67,7 @@ get_kube_proxy_image_info() {
 
     # Get the manifest list for the tag using OCI registry API
     # We need to accept the manifest list media type to get multi-arch info
-    KUBE_PROXY_MANIFEST="$(curl -sL \
+    KUBE_PROXY_MANIFEST="$(curl -fsSL \
         -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
         "https://registry.k8s.io/v2/kube-proxy/manifests/${KUBE_PROXY_LATEST_TAG}")"
 

--- a/src/okd/build_images.sh
+++ b/src/okd/build_images.sh
@@ -91,6 +91,7 @@ base_image() {
   local -r repo="${WORKDIR}/$(basename "${repo_url}")"
 
   git_clone_repo "${repo_url}" "${OCP_BRANCH}" "${repo}"
+  sed -i 's|^FROM registry.ci.openshift.org/ocp/.* AS builder|FROM quay.io/centos/centos:stream9 AS builder|' "${dockerfile_path}"
   sed -i 's|^FROM registry.ci.openshift.org/ocp/.*|FROM quay.io/centos/centos:stream9|' "${dockerfile_path}"
 
   podman build --platform "linux/${TARGET_ARCH}" -t "${images[base]}" -f "${dockerfile_path}" .

--- a/src/quickrpm.sh
+++ b/src/quickrpm.sh
@@ -70,7 +70,7 @@ function download_script() {
     if [ -f "${curscriptdir}/../${scriptpath}" ]; then
         cp -v "${curscriptdir}/../${scriptpath}" "${WORKDIR}/${script}"
     else
-        curl -fSsL --retry 5 --max-time 60 \
+        curl -fsSL --retry 5 --max-time 60 \
             "https://github.com/${OWNER}/${REPO}/raw/${BRANCH}/src/rpm/${script}" \
             -o "${WORKDIR}/${script}"
         chmod +x "${WORKDIR}/${script}"
@@ -105,7 +105,7 @@ function install_rpms_copr() {
 function install_rpms() {
     # Download the RPMs from the release
     mkdir -p "${WORKDIR}/rpms"
-    curl -L -s --retry 5 \
+    curl -fsSL --retry 5 \
         "https://github.com/${OWNER}/${REPO}/releases/download/${TAG}/microshift-rpms-$(uname -m).tgz" | \
         tar zxf - -C "${WORKDIR}/rpms"
 
@@ -156,7 +156,7 @@ fi
 # Update the 'latest' tag to the latest released version (only for github source)
 if [ "${RPM_SOURCE}" == "github" ] && [ "${TAG}" == "latest" ] ; then
     dnf install -y jq
-    TAG="$(curl -s --max-time 60 "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" | jq -r .tag_name)"
+    TAG="$(curl -fsSL --max-time 60 "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" | jq -r .tag_name)"
     if [ -z "${TAG}" ] || [ "${TAG}" == "null" ] ; then
         echo "ERROR: Could not determine the latest release tag from GitHub"
         exit 1

--- a/src/quickstart.sh
+++ b/src/quickstart.sh
@@ -200,7 +200,7 @@ check_podman_version
 # For remote images with the 'latest' tag, update the tag to the latest released version
 if [[ "${IMAGE}" != localhost/* ]] && [ "${TAG}" == "latest" ]; then
     check_prerequisites curl jq
-    TAG="$(curl -s --max-time 60 "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" | jq -r .tag_name)"
+    TAG="$(curl -fsSL --max-time 60 "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" | jq -r .tag_name)"
     if [ -z "${TAG}" ] || [ "${TAG}" == "null" ] ; then
         echo "ERROR: Could not determine the latest release tag from GitHub"
         exit 1

--- a/src/rpm/postinstall.sh
+++ b/src/rpm/postinstall.sh
@@ -14,7 +14,7 @@ install_cni_plugins() {
     [ "$(uname -m)" = "aarch64" ] && CNP_PKG="cni-plugins-linux-arm64-${CNP_VER}.tgz"
 
     # Download the package
-    curl -sSL --retry 5 -o "/tmp/${CNP_PKG}" \
+    curl -fsSL --retry 5 -o "/tmp/${CNP_PKG}" \
         "https://github.com/containernetworking/plugins/releases/download/${CNP_VER}/${CNP_PKG}"
 
     # Extract the package into the CNI plugins directory as defined


### PR DESCRIPTION
Closes #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the OKD image build’s builder base image reference to ensure the expected build stage is used.

* **Chores**
  * Improved reliability of downloads and “latest”/tag resolution by making HTTP errors fail fast across workflows and build/release scripts (including image manifest/tag selection and CNI plugin artifact retrieval).
  * Updated container and automation steps to use stricter download behavior, reducing silent or partial failures when artifacts are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->