### PR TITLE
Revert "Work around lack of 5.0 mirror repository"

### DIFF
--- a/src/rpm/create_repos.sh
+++ b/src/rpm/create_repos.sh
@@ -68,10 +68,6 @@ case $1 in
         echo "ERROR: Could not determine the MicroShift version from the RPM repository at '${repo_path}'"
         exit 1
     fi
-    # TODO: Remove this workaround once 5.0 mirror repositories are available
-    if [ "${repo_version}" = "5.0" ]; then
-        repo_version="4.22"
-    fi
     create_rhocp_repo "${repo_version}"
     ;;
 


### PR DESCRIPTION
Closes #218 

This reverts commit 4aa6dda84599372410e3f338bc04950b2f88e8bd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mirror repository generation now uses the detected RPM repository version directly, improving consistency when creating OpenShift repository files.
  * Removed an outdated version fallback that could rewrite version values during repository creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->