### PR TITLE
fix: ensure identical version across matrix builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,25 @@ on:
         - bootc-image
 
 jobs:
+  generate-version:
+    name: Generate build version
+    runs-on: ubuntu-24.04
+    outputs:
+      build-timestamp: ${{ steps.timestamp.outputs.value }}
+    steps:
+      - name: Generate build timestamp
+        id: timestamp
+        run: echo "value=$(date -u +%Y%m%d%H%M)" >> "${GITHUB_OUTPUT}"
+
   build-microshift:
+    needs: generate-version
     strategy:
       matrix:
         runners: [ubuntu-24.04, ubuntu-24.04-arm]
     name: Build MicroShift upstream
     runs-on: ${{ matrix.runners }}
+    env:
+      BUILD_TIMESTAMP: ${{ needs.generate-version.outputs.build-timestamp }}
     steps:
       - name: Check out MicroShift upstream repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ srpm:
         --build-arg OKD_VERSION_TAG="${OKD_VERSION_TAG}" \
         --build-arg OKD_RELEASE_IMAGE_X86_64="${OKD_RELEASE_IMAGE_X86_64}" \
         --build-arg OKD_RELEASE_IMAGE_AARCH64="${OKD_RELEASE_IMAGE_AARCH64}" \
+        --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" \
         -f packaging/srpm.Containerfile .
 
 	@outdir="$${SRPM_WORKDIR:-$$(mktemp -d /tmp/microshift-srpms-XXXXXX)}" && \

--- a/packaging/srpm.Containerfile
+++ b/packaging/srpm.Containerfile
@@ -83,4 +83,5 @@ RUN sed -i -e 's,CHECK_RPMS="y",,g' -e 's,CHECK_SRPMS="y",,g' ./packaging/rpm/ma
     "${USHIFT_MODIFY_SPEC_SCRIPT}" ./packaging/rpm/microshift.spec "${SPEC_KINDNET}" "${SPEC_TOPOLVM}"
 
 COPY --chmod=755 ./src/image/build-rpms.sh ${USHIFT_BUILDRPMS_SCRIPT}
+ARG BUILD_TIMESTAMP
 RUN "${USHIFT_BUILDRPMS_SCRIPT}" srpm

--- a/src/image/build-rpms.sh
+++ b/src/image/build-rpms.sh
@@ -50,7 +50,8 @@ if [[ $(git tag -l "${USHIFT_GITREF}") ]]; then
 else
     MICROSHIFT_VERSION="$(awk -F'[=.-]' '{print $2 "." $3 "." $4}' Makefile.version.aarch64.var | sed -e 's/ //g')"
     # After the X.Y.Z, add build timestamp for correct ordering of the RPMs based on the version.
-    MICROSHIFT_VERSION="${MICROSHIFT_VERSION}-$(date -u +%Y%m%d%H%M)"
+    # BUILD_TIMESTAMP can be set externally to ensure identical versions across parallel builds.
+    MICROSHIFT_VERSION="${MICROSHIFT_VERSION}-${BUILD_TIMESTAMP:-$(date -u +%Y%m%d%H%M)}"
 fi
 # Example results:
 # - 4.21.0-202511271015-ga9cd00b34_4.21.0_okd_scos.ec.5   for build against HEAD of main which was 4.21 at the time.


### PR DESCRIPTION
Generate build timestamp once in a pre-job and propagate it via BUILD_TIMESTAMP env var so all matrix runners (amd64, arm64) produce the same version string. Previously each runner called date(1) independently, causing the per-arch image tags to diverge and breaking the multi-arch manifest creation step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflows now compute a shared UTC build timestamp and use it consistently across release artifacts.
  * SRPM builds accept an optional timestamp override to help generate repeatable version numbers when desired.
  * The RPM version timestamp logic can now use the overridden value (when not building from a git tag), falling back to the prior UTC timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->